### PR TITLE
02/10/2021 front page updates, events

### DIFF
--- a/public_html/front.css
+++ b/public_html/front.css
@@ -5,35 +5,55 @@
   news cards, event options, embeds
 */
 
-/* ---- NEWS CARDS ---- */
-.news1-image{
-  height: 100%;
+/* ---- GENERAL FORMATTING ---- */
+.container{
+  padding: 50px;
+  border-radius: 10px;
 }
+.featurette-divider{
+  margin-top:50px;
+}
+
+/* ---- EVENT CARDS ---- */
+/*.card-columns {
+  @include media-breakpoint-only(md){
+    column-count: 1;
+  }
+  @include media-breakpoint-only(sm){
+    column-count: 1;
+  }
+} not working!
+
+/* ---- NEWS CARDS ---- */
 .news-card{
-  background-color:#fff;
-  box-shadow:1px 1px 2px #7D7D7D;
+  background-color:#FFF;
+  border-style:solid;
+  border-color:#ADDA83;
+  border-width:1px;
   border-radius: 10px;
   display:flex;
   overflow:auto;
-  margin-bottom: 30px;
-  padding: 10px;
+  min-height:15vw;
+  margin-bottom:25px;
+  text-align: center;
+}
+.card-header{
+  background-color:#ADDA83;
+  color:#FFF;
+}
+.headline{
+  margin-bottom:15px;
 }
 .news-text{
   width:100%;
-  padding:20px;
+  padding-left:15px;
+  padding-right:15px;
 }
 .news-image{
-  padding-right:2vw;
   height:15vw;
   width:15vw;
 }
-.headline{
-  text-align:center;
-}
-.date{
-  text-align:left;
-  color:#545454;
-}
+
 
 /* ---- TWITTER TIMELINE EMBED --- */
 .twitter-timeline{

--- a/public_html/index.css
+++ b/public_html/index.css
@@ -28,6 +28,7 @@ body{
 }
 
 
+
 /* -------OLD NAVBAR------- */
 /* these classes are only necessary if the navbar contains a dropdown menu */
 

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -131,66 +131,85 @@
 		  <a class="carousel-control-next" href="#move" data-slide="next">
 		    <span class="carousel-control-next-icon"></span>
 		  </a>
-
 		</div>
 
 <!-- ==== TITLE =========================================================== -->
-		<main id="content-main" class="flex-grow-1 p-5">
+		<main id="content-main" class="flex-grow-1 p-5" style="background-color:#93B6D9">
+
+		<div class="container" style="background-color:#FFF">
 			<h1 class"heading">Undergraduate Diversity and Inclusion in Physics</h1>
 			<p class="lead">UDIP is a club committed to creating a welcoming environment within the physics department at UCSB. We work with the department and coordinate with faculty, students, and other clubs to put on great events and provide resources. </p>
-			<br>
+
 
 
 <!-- ==== EVENTS =========================================================== -->
 			<hr class="featurette-divider">
-			<div class="col-md-8">
 				<h1 class="heading">Upcoming Events</h1>
 				<p class="lead">Updated February 8, 2021</p>
-			</div>
-			<div class="row">
-	<!-- EVENT ENTRY 1 -->
-				<div class="col-md">
-					<div class="news-card center" style="min-height:20vw;">
-						<div class="news-text">
-							<h4 class="headline">Microsoft Career Panel</h4>
-							<p>
-								Thursday, February 11, 6-7pm PST</p>
-								<p>Join us <a href="https://ucsb.zoom.us/j/85918700675">here</a> for a virtual career panel with Microsoft employees! </p>
-								<p>Hear from engineers, researchers, and program managers about what their jobs entail and the career paths they took to their current positions.</p>
-								<p>Panelists: Stephen Jorder (researcher studying alogirthms with the Quantum Program), ariia Mykhailova (software engineer with the Quantum Program), Will Labor (program manager in Azure Hardware Systems and Infrastructure), and Georg Winkler (theoretical physics researcher with the Quantum Program).
-							</p>
-						</div>
+			<div class="card-columns">
+
+				<div class="card news-card">
+					<div class="card-header"></div>
+					<div class="card-body">
+						<h4 class="headline">Microsoft Career Panel</h4>
+						<p class="news-text">
+							Thursday, February 11, 6-7pm PST</p>
+							<p>Join us <a href="https://ucsb.zoom.us/j/85918700675">here</a> for a virtual career panel with Microsoft employees! </p>
+							<p>Hear from engineers, researchers, and program managers about what their jobs entail and the career paths they took to their current positions.</p>
+							<p>Panelists: Stephen Jorder (researcher studying alogirthms with the Quantum Program), ariia Mykhailova (software engineer with the Quantum Program), Will Labor (program manager in Azure Hardware Systems and Infrastructure), and Georg Winkler (theoretical physics researcher with the Quantum Program).
 					</div>
 				</div>
 
-	<!-- EVENT ENTRY 2 -->
-				<div class="col-md">
-					<div class="news-card center" style="min-height:20vw;">
-						<div class="news-text">
-							<h4 class="headline">Weekly UDIP Meetings</h4>
-							<p>
-								Weekly on Wednesdays, 6-7pm PST</p>
-								<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
-								<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
-							</p>
-						</div>
+				<div class="card news-card">
+					<div class="card-header"></div>
+					<div class="card-body">
+						<h4 class="headline">Weekly UDIP Meetings</h4>
+						<p class="news-text">
+							Weekly on Wednesdays, 6-7pm PST</p>
+							<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
+							<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
+					</div>
+				</div>
+<!--
+				<div class="card news-card">
+					<div class="card-header"></div>
+					<img class="card-img-top" src="images/astro_society_graphic.jpg">
+					<div class="card-body">
+						<h4 class="headline">Weekly UDIP Meetings</h4>
+						<p class="news-text">
+							Weekly on Wednesdays, 6-7pm PST</p>
+							<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
+							<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
 					</div>
 				</div>
 
-	<!-- EVENT ENTRY 3 -->
-<!--				<div class="col-md">
-					<div class="news-card center" style="min-height:20vw;">
-						<div class="news-text">
-							<h4 class="headline">EVENT NAME</h4>
-							<p>
-								DESCRIPTION GOES HERE
-							</p>
-						</div>
+				<div class="card news-card">
+					<div class="card-header"></div>
+					<img class="card-img-top" src="images/2020winter/Professional_Events_Calander.png">
+					<div class="card-body">
+						<h4 class="headline">Weekly UDIP Meetings</h4>
+						<p class="news-text">
+							Weekly on Wednesdays, 6-7pm PST</p>
+							<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
+							<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
+					</div>
+				</div>
+
+				<div class="card news-card">
+					<div class="card-header"></div>
+					<img class="card-img-top" src="images/UCSB_physics.jpg">
+					<div class="card-body">
+						<h4 class="headline">Weekly UDIP Meetings</h4>
+						<p class="news-text">
+							Weekly on Wednesdays, 6-7pm PST</p>
+							<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
+							<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
 					</div>
 				</div>
 -->
+			</div>
 
-<!-- ==== NEWS ============================================================ -->
+<!-- ===== NEWS DIVIDER ========================================= -->
 			<div class="col-md-12">
 				<hr class="featurette-divider">
 				<h1 class="heading">News</h1>
@@ -199,112 +218,109 @@
 
 			<div class="row">
 				<div class="col-md-8 themed-grid-col">
-					<div class="news-card center" style="min-height:20vw;">
-						<div class="news-text">
-							<h6 class="date">19th January 2021</h6>
-							<br>
+
+<!-- ==== NEWS ENTRIES ============================================================ -->
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<img class="card-img" src="images/talent_show_2021.png">
+						<div class="card-body">
+							<h4 class="headline">UCSB Physics Talent Show</h4>
+							<p class="news-text">
+							Grad life put together a fantastic playbill of undergraduate, graduate, and even faculty talents!</p>
+							<p class="news-text">Among the live acts featured were
+							 graduate students Sarah Steiger, Will Schultz, and Josh Straub performing dance,
+							 graduate student Alex Dorsett performing guitar,
+							 faculty Mark Sherwin performing flute,
+							 undergraduate Richard Yang performing guitar,
+							 faculty Deborah Fygenson performing poetry,
+							 graduate student Jamie Burke performing calligraphy,
+							 and graduate student George Hulsey performing guitar.</p>
+						</div>
+						<div class="card-footer text-muted">22nd January 2021</div>
+					</div>
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
 							<h4 class="headline">Women in Physics panel</h4>
-							<p>
+							<p class="news-text">
 								SPS, UDIP, and WiP had the pleasure of co-hosting the women in physics panel. The panelists were Mindy Harkness, Molly Wolfson, Gabi Abrahams, and Dr. Sathya Guruswamy. They had wonderful words of wisdom to share, and the notes on this will be uploaded shortly.
 							</p>
 						</div>
+						<div class="card-footer text-muted">19 January 2021</div>
 					</div>
-					<div class="news-card center" style="min-height:20vw;">
-					<div class="news-text">
-						<h6 class="date">22nd January 2021</h6>
-						<br>
-						<h4 class="headline">UCSB Physics Talent show</h4>
-						<p>
-							Grad life put together a fantastic playbill of undergraduate, graduate and even faculty talents!
-							<img src = "images/talent_show_2021.png" class = "news-image">
-						</p>
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">First Generation Panel</h4>
+							<p class="news-text">
+								UCSB Physics department professors Lubin, Pincus, and Martinis were all first generation professors. Watch students Lesley-Garcia Huerta, and Sean Benevides, both first - generation undergraduates lead the first-gen panel.</p>
+							<p class="news-text"> Login <a href="https://ucsb.box.com/s/pg5lyx1ah6hfgi7382nsef1nmm1akgpt">here</a> with your UCSBnetID to access the recorded videos!
+							</p>
+						</div>
+						<div class="card-footer text-muted">10 November 2020</div>
 					</div>
-				</div>
-				<div class="news-card center" style="min-height:20vw;">
-					<div class="news-text">
-						<h6 class="date">10 November 2020</h6>
-						<br>
-						<h4 class="headline">First Generation Panel</h4>
-						<p>
-							UCSB Physics department professors Lubin, Pincus, and Martinis were all first generation professors. Watch students Lesley-Garcia Huerta, and Sean Benevides, both first - generation undergraduates lead the first-gen panel.
-							The following link is a box link, for which you will require your UCSB NetID to access the video. <a href = "https://ucsb.box.com/s/pg5lyx1ah6hfgi7382nsef1nmm1akgpt">First-Gen panel UDIP - recording</a>
-						</p>
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">UDIP New Student Panel</h4>
+							<p class="news-text">
+								Our New Student Panel was highly successful, and we hope that you found it helpful as well!</p>
+							<p class="news-text"> Click <a href="resources/UDIP New Student Welcome Panel.pdf">here</a> to access the slides,
+								<a href="resources/panel_transcript.txt">here</a> to access the meeting transcript, or
+								<a href="resources/chat.txt">here</a> to access the chat records!
+							</p>
+						</div>
+						<div class="card-footer text-muted">1 October 2020</div>
 					</div>
-				</div>
-				<div class="news-card center" style="min-height:20vw;">
-					<div class="news-text">
-						<h6 class="date">1st October 2020</h6>
-						<br>
-						<h4 class="headline">UDIP New Student Panel Transcript</h4>
-						<p>
-							The Panel was highly successful, and we hope that you found it helpful as well!
-							<ul>
-								<li>Here is the link to the slides for the meeting: <a href = 'resources/UDIP New Student Welcome Panel.pdf'>Slides</a></li>
-								<li>Here is the link to the meeting transcipt:<a href = 'resources/panel_transcript.txt'>Transcript</a></li>
-								<li>Here is the link to the chat transcript: <a href = 'resources/chat.txt'>Chat</a></li>
-							</ul>
-						</p>
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">Undergraduate Seminar Series</h4>
+							<p class="news-text">
+								Are you curious about applying your skills in a research setting? Looking to branch out of academia and venture into industry? Are you wondering what you're going to do after getting your degree? We're happy to help guide you through these big decisions! Beginning this Fall Quarter, we'll be hosting a seminar series on general application strategies for fellowships, research opportunities, grad school, and industry. We'll be discussing
+								<ol>
+									<li> How to build a strong application </li>
+									<li> How to write a compelling personal statement </li>
+									<li> How to build a CV and Resumé </li>
+									<li> How to apply for summer research opportunities or internships </li>
+									<li> How to choose a graduate program or job in industry </li>
+									<li> How to transition from academia to industry </li>
+								</ol>
+								We also plan to host two panels: one with professors from admission committees and the other with graduated students. In addition, several of our sessions will be dedicated to helping students one on one with application materials! This will be useful to seniors who are preparing applications, and students earlier in their career by learning what makes a strong application.
+								If you are interested in attending these sessions, please take a moment to fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSdKXUwI-fbr9CDhtfbSCmc1zmQ5bRwHWNBFMgzov8vtX6TBVg/viewform">this survey</a>. We are very interested to hear of specific topics you'd like to discuss!
+							</p>
+						</div>
+						<div class="card-footer text-muted">19 September 2020</div>
 					</div>
-				</div>
-				<div class="news-card center" style="min-height:20vw;">
-						<div class="news-text">
-							<h6 class="date">1st October 2020</h6>
-							<br>
-							<h4 class="headline">UDIP New Student Panel Transcript</h4>
-							<p>
-								The Panel was highly successful, and we hope that you found it helpful as well!
+
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">UCSB/IV COVID-19 News</h4>
+							<p class="news-text">
+								Our New Student Panel was highly successful, and we hope that you found it helpful as well!</p>
+							<p class="news-text">
 								<ul>
-									<li>Here is the link to the slides for the meeting: <a href = 'resources/UDIP New Student Welcome Panel.pdf'>Slides</a></li>
-									<li>Here is the link to the meeting transcipt:<a href = 'resources/panel_transcript.txt'>Transcript</a></li>
-									<li>Here is the link to the chat transcript: <a href = 'resources/chat.txt'>Chat</a></li>
+									<li>UCSB SHS is providing free testing for those who show symptoms. Those who test positive MUST quarantinte for 14 days.</li>
+									<li>All students coming back for Fall quarter must quarantine for 7 days.</li>
+									<li>Students throwing or attending parties in Isla Vista will have a one time warning before their institution is notified. UCSB students and organisations will be dealt with accordingly, and peer-to-peer accountability is encouraged.</li>
+									<li>anta Barbara County reported 19 new cases of COVID-19 on Thursday. There are a total of 172 infectious (active) cases (24 in Isla Vista). Twenty-eight (28) people are hospitalized, with seven (7) patients in the ICU. To date, there are 109 COVID-19 related deaths and 8,803 confirmed cases countywide.</li>
 								</ul>
 							</p>
 						</div>
+						<div class="card-footer text-muted">18 September 2020</div>
 					</div>
 
-					<div class="news-card center" style="min-height:39vw;">
-						<div class="news-text">
-							<h6 class="date">19th September 2020</h6>
-							<br>
-							<h4 class="headline">Undergraduate Seminar Series</h4>
-							<p>
-								Are you curious about applying your skills in a research setting? Looking to branch out of academia and venture into industry? Are you wondering what you're going to do after getting your degree? We're happy to help guide you through these big decisions! Beginning this Fall Quarter, we'll be hosting a seminar series on general application strategies for fellowships, research opportunities, grad school, and industry. We'll be discussing
-									<ol>
-										<li> How to build a strong application </li>
-										<li> How to write a compelling personal statement </li>
-										<li> How to build a CV and Resumé </li>
-										<li> How to apply for summer research opportunities or internships </li>
-										<li> How to choose a graduate program or job in industry </li>
-										<li> How to transition from academia to industry </li>
-									</ol>
-			We also plan to host two panels: one with professors from admission committees and the other with graduated students. In addition, several of our sessions will be dedicated to helping students one on one with application materials! This will be useful to seniors who are preparing applications, and students earlier in their career by learning what makes a strong application.
-			If you are interested in attending these sessions, please take a moment to fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSdKXUwI-fbr9CDhtfbSCmc1zmQ5bRwHWNBFMgzov8vtX6TBVg/viewform">this survey</a>. We are very interested to hear of specific topics you'd like to discuss!
-							</p>
-						</div>
-					</div>
-
-					<div class="news-card center" style="min-height:25vw;">
-						<div class="news-text">
-							<h6 class="date">18th September 2020</h6>
-							<br>
-							<h4 class="headline">UCSB/IV COVID-19 News</h4>
-							<p>
-							<ul>
-								<li>UCSB SHS is providing free testing for those who show symptoms. Those who test positive MUST quarantinte for 14 days.</li>
-								<li>All students coming back for Fall quarter must quarantine for 7 days.</li>
-								<li>Students throwing or attending parties in Isla Vista will have a one time warning before their institution is notified. UCSB students and organisations will be dealt with accordingly, and peer-to-peer accountability is encouraged.</li>
-								<li>anta Barbara County reported 19 new cases of COVID-19 on Thursday. There are a total of 172 infectious (active) cases (24 in Isla Vista). Twenty-eight (28) people are hospitalized, with seven (7) patients in the ICU. To date, there are 109 COVID-19 related deaths and 8,803 confirmed cases countywide.</li>
-							</ul>
-							</p>
-						</div>
-					</div>
-
-					<div class="news-card center" style="min-height:25vw;">
-						<div class="news-text">
-							<h6 class="date">16th September 2020</h6>
-							<br>
-							<h4 class="headline">UDIP requests for the Fall Quarter</h4>
-							<p>
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">UDIP Requests for the Fall Quarter</h4>
+							<p class="news-text">
 								UDIP's requests for the Fall included things such as:
 								<ul>
 									<li>Free kits for 127AL</li>
@@ -317,19 +333,25 @@
 								up in faculty meetings, and has encouraged future communication. We greatly appreciate this cooperation from the department.
 							</p>
 						</div>
+						<div class="card-footer text-muted">16 September 2020</div>
 					</div>
 
-					<div class="news-card center" style="min-height:15vw;">
-						<div class="news-text">
-							<h6 class="date">16th September 2020</h6>
-							<br>
-							<h4 class="headline">UDIP requests for Freshman Orientation</h4>
-							<p>
+					<div class="card news-card">
+						<div class="card-header"></div>
+						<div class="card-body">
+							<h4 class="headline">UDIP Requests for Freshman Orientation</h4>
+							<p class="news-text">
+								Our New Student Panel was highly successful, and we hope that you found it helpful as well!</p>
+							<p class="news-text">
 								UDIP compiled a list of reccommendations for improving freshman orientation you can find <a href="images/UDIP_Orientation_Suggestions.pdf">here</a>. We will be working with advisors to ensure that these are read and maintained. Updates will be posted here.
 							</p>
 						</div>
+						<div class="card-footer text-muted">16 September 2020</div>
 					</div>
+
 				</div>
+
+
 
 
 <!-- ===== RIGHT COLUMN ===== -->
@@ -361,6 +383,7 @@
 				<!-- i realized that theres also a resources list in the footer but IDK-->
 				</div>
 			</div>
+		</div>
 		</main>
 
 <!--===== FOOTER ===========================================================-->

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -145,35 +145,40 @@
 			<hr class="featurette-divider">
 			<div class="col-md-8">
 				<h1 class="heading">Upcoming Events</h1>
-				<p class="lead">Updated 1/23/2021</p>
+				<p class="lead">Updated February 8, 2021</p>
 			</div>
 			<div class="row">
 	<!-- EVENT ENTRY 1 -->
-				<div class="col-md-4">
+				<div class="col-md">
 					<div class="news-card center" style="min-height:20vw;">
 						<div class="news-text">
-							<h4 class="headline">Microsoft Career Panel - Feb 11, 6PM</h4>
+							<h4 class="headline">Microsoft Career Panel</h4>
 							<p>
-								zoom link, description
+								Thursday, February 11, 6-7pm PST</p>
+								<p>Join us <a href="https://ucsb.zoom.us/j/85918700675">here</a> for a virtual career panel with Microsoft employees! </p>
+								<p>Hear from engineers, researchers, and program managers about what their jobs entail and the career paths they took to their current positions.</p>
+								<p>Panelists: Stephen Jorder (researcher studying alogirthms with the Quantum Program), ariia Mykhailova (software engineer with the Quantum Program), Will Labor (program manager in Azure Hardware Systems and Infrastructure), and Georg Winkler (theoretical physics researcher with the Quantum Program).
 							</p>
 						</div>
 					</div>
 				</div>
 
 	<!-- EVENT ENTRY 2 -->
-				<div class="col-md-4">
+				<div class="col-md">
 					<div class="news-card center" style="min-height:20vw;">
 						<div class="news-text">
-							<h4 class="headline">EVENT NAME</h4>
+							<h4 class="headline">Weekly UDIP Meetings</h4>
 							<p>
-								DESCRIPTION GOES HERE
+								Weekly on Wednesdays, 6-7pm PST</p>
+								<p>Join our weekly meetings and learn more about what we're currently doing for the UCSB Physics community!</p>
+								<p>Click <a href="https://ucsb.zoom.us/j/265401222">here</a> to join!
 							</p>
 						</div>
 					</div>
 				</div>
 
 	<!-- EVENT ENTRY 3 -->
-				<div class="col-md-4">
+<!--				<div class="col-md">
 					<div class="news-card center" style="min-height:20vw;">
 						<div class="news-text">
 							<h4 class="headline">EVENT NAME</h4>
@@ -183,7 +188,7 @@
 						</div>
 					</div>
 				</div>
-
+-->
 
 <!-- ==== NEWS ============================================================ -->
 			<div class="col-md-12">


### PR DESCRIPTION
pretty sure the front page looks better now?
also, added event and news card templates to the wiki.

commit notes:
- events update, 2/9/2021
- reworked front.html to include more colors, better division
- events list now supports any amount of event tiles and will tile them 
according to length (assuming there are >3 cards at once) via card-columns class
- adjusted width of the page content by enclosing it in a container, should improve UX on larger screens

